### PR TITLE
Allow XPath queries to extract attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the `hyper_api` gem to your app. For example, using Bundler:
 
 ## Usage
 
-The HyperAPI gem uses [Nokogiri](https://github.com/sparklemotion/nokogiri) to parse HTML with CSS selectors.
+The HyperAPI gem uses [Nokogiri](https://github.com/sparklemotion/nokogiri) to parse HTML with CSS or XPath selectors.
 
 Create objects on-the-go:
 
@@ -20,7 +20,7 @@ Torrent = HyperAPI.new_class do
   string title: 'div#title'
   string description: 'div.info'
   string hash: '#details dd'
-  integer imdb_id: '#details a[title=IMDB]' do
+  integer imdb_id: "//[@id='details']/a[@title='IMDB']" do
     attribute('href').value
   end
 end

--- a/lib/hyper_api.rb
+++ b/lib/hyper_api.rb
@@ -39,7 +39,7 @@ module HyperAPI
       known_attributes.each do |attr, options|
         type, path, block = options
 
-        unless (value = html.css(path)).empty?
+        unless (value = html.search(path)).empty?
           value = block ? value.instance_eval(&block) : value.text
           value = value.send("to_#{type[0]}")
         end

--- a/spec/hyper_api_spec.rb
+++ b/spec/hyper_api_spec.rb
@@ -9,10 +9,22 @@ describe HyperAPI do
     end
   end
 
-  it 'loads attributes from html string'do
+  it 'loads attributes from html string' do
     person = HyperAPI.new_class do
       string name: 'div#name'
       integer imdb_id: 'div#imdb'
+    end
+
+    bob = person.new('<div id="name">Bob</div><div id="imdb">111999</div>')
+
+    expect(bob.name).to eq('Bob')
+    expect(bob.imdb_id).to eq(111999)
+  end
+
+  it 'allows XPath queries' do
+    person = HyperAPI.new_class do
+      string name: "//div[@id='name']"
+      integer imdb_id: "//div[@id='imdb']"
     end
 
     bob = person.new('<div id="name">Bob</div><div id="imdb">111999</div>')


### PR DESCRIPTION
It seems [Nokogiri::XML::NodeSet#css](https://github.com/sparklemotion/nokogiri/blob/master/lib/nokogiri/xml/node_set.rb#L94..L118) already supports XPath queries, by parsing the CSS selector to XPath.

Using `Nokogiri::XML::NodeSet#search` makes it more explicit that XPath can be used.
